### PR TITLE
Automatically detect serial port devices

### DIFF
--- a/config.c
+++ b/config.c
@@ -70,6 +70,7 @@ void read_parms()
 	/* Read personal parameters */
 	if ((fp = sfopen(pparfile, "r")) != (FILE *)NULL)
 	{
+		fprintf(stderr, "Also using personal configuration from %s\n", pparfile);
 		readpars(fp, 0);
 		fclose(fp);
 	}

--- a/remote_launch
+++ b/remote_launch
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+POSSIBLE_SP1_LOCATIONS=( "/dev/serial/by-id/usb-Digilent_Digilent_USB_Device_*-if01-port0" )
+
+echo "# Automatically generated based on this system's actual location for the first serial port" > ~/.remoterc.dfl
+echo -e "pu port\t" $POSSIBLE_SP1_LOCATIONS >> ~/.remoterc.dfl
+
+remote_bin

--- a/remoterc.dfl
+++ b/remoterc.dfl
@@ -8,7 +8,7 @@ pu pname6           YDNY
 pu pname7           YUYN
 pu pname8           NDYN
 pu pprog1           down
-pr port             /dev/ttyUSB1
-pu baudrate         38400
+#pr port             Set this to one of the symlinks in /dev/serial/by-id/<XXX> depending on which device SP1 is
+pr baudrate         38400
 pu rtscts           No 
 pu mfcolor          RED

--- a/rwconf.c
+++ b/rwconf.c
@@ -93,13 +93,13 @@ struct pars mpars[] = {
   { "",			PUBLIC,   "pprog11" },
   { "",			PUBLIC,   "pprog12" },
   /* Serial port & friends */
-  { DFL_PORT,		PRIVATE,  "port" },
+  { DFL_PORT,		PUBLIC,  "port" },
   { CALLIN,		PRIVATE,  "callin" },
   { CALLOUT,		PRIVATE,  "callout" },
   { UUCPLOCK,		PRIVATE,  "lock" },
-  { DEF_BAUD,		PUBLIC,   "baudrate" },
-  { "8",		PUBLIC,   "bits" },
-  { "N",		PUBLIC,   "parity" },
+  { DEF_BAUD,		PRIVATE,   "baudrate" },
+  { "8",		PRIVATE,   "bits" },
+  { "N",		PRIVATE,   "parity" },
   /* Kermit the frog */
   { KERMIT,		PRIVATE,  "kermit" },
   { "Yes",		PRIVATE,  "kermallow" },
@@ -214,14 +214,14 @@ FILE *fp;
 int init;
 {
   struct pars *p;
-  char line[80];
+  char line[300];
   char *s;
   int public;
   int dosleep = 0;
 
   if (init) strcpy(P_SCRIPTPROG, "runscript");
 
-  while(fgets(line, 80, fp) != (char *)0) {
+  while(fgets(line, 300, fp) != (char *)0) {
 
   	s = strtok(line, "\n\t ");
 	if (s == NULL) continue;

--- a/sp2_launch
+++ b/sp2_launch
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+POSSIBLE_SP2_LOCATIONS=( "/dev/serial/by-id/usb-FTDI_FT232R_USB_UART_*-if00-port0" )
+
+screen $POSSIBLE_SP2_LOCATIONS 38400 


### PR DESCRIPTION
This includes some new wrapper scripts that need to be placed in the /home/compx203/bin folder on the lab computers.